### PR TITLE
teeny tiny errors

### DIFF
--- a/src/core/init-dfp.ts
+++ b/src/core/init-dfp.ts
@@ -20,7 +20,7 @@ export interface Dfp<Params extends CommandParams> {
     listener: ListenerModule;
 }
 
-export function initDiscordFP(config: DfpConfig) {
+export function initDiscordFP(config: DfpConfig = {}) {
     const dfp: Dfp<{ _ctx: {} }> = {
         command: initCommandBuilder(),
         loaded: [],

--- a/src/core/init-dfp.ts
+++ b/src/core/init-dfp.ts
@@ -20,6 +20,9 @@ export interface Dfp<Params extends CommandParams> {
     listener: ListenerModule;
 }
 
+/** @deprecated Always call this function with config. */
+export function initDiscordFP(): Dfp<{ _ctx: {} }>;
+export function initDiscordFP(config: DfpConfig): Dfp<{ _ctx: {} }>;
 export function initDiscordFP(config: DfpConfig = {}) {
     const dfp: Dfp<{ _ctx: {} }> = {
         command: initCommandBuilder(),

--- a/src/slash/slash.ts
+++ b/src/slash/slash.ts
@@ -60,7 +60,7 @@ export class SlashCommandLoader implements FileLoader {
 
     constructor(config: SlashCommandConfig<any, any>) {
         this.config = config;
-        this.optionMap = Object.entries<Option<unknown>>(this.config.options);
+        this.optionMap = Object.entries<Option<unknown>>(this.config.options ?? {});
     }
 
     onEvent = (e: ChatInputCommandInteraction) => {


### PR DESCRIPTION
Fix:
1.compiler error when `initDiscordFP` called without config
=> deprecated warning when called without config
2.empty option in slash command will throw TypeError
![image](https://user-images.githubusercontent.com/50331539/229326770-822c578f-44a5-468d-b848-0142472d5a1f.png)
=> allow creating slash command without option